### PR TITLE
fix: Deal with both $ref and properties in the same schema

### DIFF
--- a/crdsonnet/parser.libsonnet
+++ b/crdsonnet/parser.libsonnet
@@ -11,6 +11,58 @@ local schemadb_util = import './schemadb.libsonnet';
 
   getRefName(ref): std.reverse(std.split(ref, '/'))[0],
 
+  //parseSchema(key, schema, currentSchema, schemaDB={}, parents=[]):
+  //  if std.isBoolean(schema)
+  //  then { [key]+: schema }
+  //  else if !std.isObject(schema)
+  //  then error 'Schema is not an object or boolean'
+  //  else
+  //    local resolved =
+  //      if '$ref' in schema
+  //      then
+  //        this.resolveRef(
+  //          schema['$ref'],
+  //          currentSchema,
+  //          schemaDB
+  //        )
+  //      else {};
+
+  //    local currentResolved =
+  //      std.get(
+  //        resolved,
+  //        '_currentSchema',
+  //        currentSchema,
+  //        true
+  //      );
+  //    local merged = std.mergePatch(schema, resolved);
+  //    local parsed = [
+  //      'properties',
+  //      'items',
+  //      'then',
+  //      'else',
+  //      'prefixItems',
+  //      'allOf',
+  //      'anyOf',
+  //      'oneOf',
+  //    ];
+  //    {
+  //      [key]+: {
+  //        [k]+: merged[k]
+  //        for k in std.objectFields(merged)
+  //        if !std.member(parsed, k)
+  //      },
+  //    }
+  //    + this._parseSchema(key, schema, currentSchema, schemaDB, parents)
+  //    + (
+  //      if '$ref' in schema
+  //      then this._parseSchema(key, resolved, currentResolved, schemaDB, parents)
+  //      else {}
+  //    )
+  //    + { [key]+: { _parents: parents } }
+  //,
+  // foldEnd
+
+
   parseSchema(key, schema, currentSchema, schemaDB={}, parents=[]):
     // foldStart
     if std.isBoolean(schema)


### PR DESCRIPTION
> In Draft 4-7, $ref behaves a little differently. When an object contains a $ref property, the object is considered a reference, not a schema. Therefore, any other properties you put in that object will not be treated as JSON Schema keywords and will be ignored by the validator. $ref can only be used where a schema is expected.
_source:_ http://json-schema.org/understanding-json-schema/structuring.html#id18

wip