### PR TITLE
fix: merge xof parts in object

### DIFF
--- a/crdsonnet/dynamic.libsonnet
+++ b/crdsonnet/dynamic.libsonnet
@@ -36,7 +36,14 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
           'value',
           (if 'type' in schema
            then schema.type
-           else 'string')
+           else 'string'),
+          (if 'const' in schema
+           then schema.const
+           else if 'default' in schema
+           then schema.default
+           else if 'enum' in schema
+           then 'enum[%s]' % std.join(',', [std.toString(x) for x in schema.enum])
+           else null)
         )]
       ),
   },

--- a/crdsonnet/dynamic.libsonnet
+++ b/crdsonnet/dynamic.libsonnet
@@ -32,19 +32,30 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         help=(if 'description' in schema
               then schema.description
               else ''),
-        args=[d.arg(
-          'value',
-          (if 'type' in schema
-           then schema.type
-           else 'string'),
-          (if 'const' in schema
-           then schema.const
-           else if 'default' in schema
-           then schema.default
-           else if 'enum' in schema
-           then 'enum[%s]' % std.join(',', [std.toString(x) for x in schema.enum])
-           else null)
-        )]
+        args=(
+          if 'const' in schema
+          then []
+          else [
+            d.arg(
+              'value',
+              type=(
+                if 'type' in schema
+                then schema.type
+                else 'string'
+              ),
+              default=(
+                if 'default' in schema
+                then schema.default
+                else null
+              ),
+              enums=(
+                if 'enum' in schema
+                then schema.enum
+                else null
+              )
+            ),
+          ]
+        )
       ),
   },
 

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -97,7 +97,10 @@
 
     const(schema): r.withConstant(schema),
 
-    boolean(schema): r.withBoolean(schema),
+    boolean(schema):
+      if '_name' in schema
+      then r.withBoolean(schema)
+      else r.nilvalue,
 
     other(schema):
       // foldStart


### PR DESCRIPTION
For Grafonnet: It seems to make sense to merge the allOf and anyOf into properties when rendering. I'm not 100% sure if and how it will affect other libraries using this, I can revert if this poses a problem and turn this into an optional render flag.