### PR TITLE
feat: add validation to dymanic render engine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: CI
+on: [pull_request]
+
+env:
+  JSONNET_VERSION: '0.20.0'
+  JSONNET_BUNDLER_VERSION: '0.5.1'
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PATH
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install jsonnet
+        shell: bash
+        run: |
+          wget https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_${JSONNET_VERSION}_Linux_x86_64.tar.gz
+          tar --extract --file=go-jsonnet_${JSONNET_VERSION}_Linux_x86_64.tar.gz jsonnet
+          mv jsonnet "$HOME/.local/bin"
+          chmod u+x "$HOME/.local/bin/jsonnet"
+
+      - name: Install jsonnet-bundler
+        shell: bash
+        run: |
+          wget https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v${JSONNET_BUNDLER_VERSION}/jb-linux-amd64
+          mv jb-linux-amd64 "$HOME/.local/bin/jb"
+          chmod u+x "$HOME/.local/bin/jb"
+
+      - name: Tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,7 @@ test:
 		RESULT=$$(($$RESULT + $$?)); \
 	done; \
 	exit $$RESULT
+
+.PHONY: fmt
+fmt:
+	jsonnetfmt -i --no-use-implicit-plus */*sonnet

--- a/crdsonnet/dynamic.libsonnet
+++ b/crdsonnet/dynamic.libsonnet
@@ -4,6 +4,8 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
   nilvalue:: {},
 
+  validate(schema, value):: true,
+
   nestInParents(name, parents, object)::
     std.foldr(
       function(p, acc)
@@ -64,10 +66,12 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + (if 'default' in schema
        then {
          [this.functionName(schema._name)](value=schema.default):
+           assert this.validate(schema, value);
            this.nestInParents(schema._name, schema._parents, { [schema._name]: value }),
        }
        else {
          [this.functionName(schema._name)](value):
+           assert this.validate(schema, value);
            this.nestInParents(schema._name, schema._parents, { [schema._name]: value }),
        }),
 
@@ -82,6 +86,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     this.functionHelp(this.functionName(schema._name), schema)
     + {
       [this.functionName(schema._name)](value=true):
+        assert this.validate(schema, value);
         this.nestInParents(schema._name, schema._parents, { [schema._name]: value }),
     },
 
@@ -89,6 +94,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     this.functionHelp(this.functionName(schema._name) + 'Mixin', schema)
     + {
       [this.functionName(schema._name) + 'Mixin'](value):
+        assert this.validate(schema, value);
         this.nestInParents(schema._name, schema._parents, { [schema._name]+: value }),
     },
 
@@ -97,6 +103,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + this.functionHelp(this.functionName(schema._name) + 'Mixin', schema)
     + {
       [this.functionName(schema._name)](value):
+        assert this.validate(schema, value);
         this.nestInParents(
           schema._name,
           schema._parents,
@@ -104,6 +111,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         ),
 
       [this.functionName(schema._name) + 'Mixin'](value):
+        assert this.validate(schema, value);
         this.nestInParents(
           schema._name,
           schema._parents,

--- a/crdsonnet/jsonnetfile.json
+++ b/crdsonnet/jsonnetfile.json
@@ -4,6 +4,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/Duologic/validate-libsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/jsonnet-libs/docsonnet.git",
           "subdir": "doc-util"
         }

--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -36,6 +36,9 @@ local defaultRenderEngine = 'dynamic';
     withRenderEngine(engine): {
       renderEngine: render.new(engine),
     },
+    withVaidation(): {
+      renderEngine+: render.withValidation(),
+    },
   },
 
   fromSchema(name, schema, schemaDB={}, renderEngine=defaultRenderEngine):

--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -118,7 +118,7 @@ local defaultRenderEngine = 'dynamic';
   // XRDs are very similar to CRDs, processing them requires slightly different behavior.
   xrd:
     self.crds
-    {
+    + {
       getKind(definition):
         if std.objectHas(definition.spec, 'claimNames')
         then definition.spec.claimNames.kind

--- a/crdsonnet/parser.libsonnet
+++ b/crdsonnet/parser.libsonnet
@@ -85,7 +85,7 @@ local schemadb_util = import './schemadb.libsonnet';
     if parsed != null
     then
       if std.isObject(parsed[key])
-      then parsed[key] { _name:: key }
+      then parsed[key] + { _name:: key }
       else parsed[key]
     else {},
   // foldEnd
@@ -133,7 +133,7 @@ local schemadb_util = import './schemadb.libsonnet';
         else '';
 
       // Because order may matter (for example for prefixItems), we return a list.
-      parsed { [if name != '' then '_name']:: name }
+      parsed + { [if name != '' then '_name']:: name }
       for item in list
     ],
   // foldEnd

--- a/crdsonnet/parser.libsonnet
+++ b/crdsonnet/parser.libsonnet
@@ -14,7 +14,7 @@ local schemadb_util = import './schemadb.libsonnet';
   getURIBase(uri): std.join('/', std.splitLimit(uri, '/', 5)[0:3]),
   getURIPath(uri): '/' + std.join('/', std.splitLimit(uri, '/', 5)[3:]),
 
-  parseSchema(key, schema, currentSchema, schemaDB={}, parents=[]):
+  parseSchema(key, schema, currentSchema=schema, schemaDB={}, parents=[]):
     // foldStart
     if std.isBoolean(schema)
     then { [key]+: schema }

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -128,7 +128,7 @@
         else r.nilvalue
       );
 
-      local xofParts = self.xofParts(schema { _parents: super._parents[1:] });
+      local xofParts = self.xofParts(schema + { _parents: super._parents[1:] });
 
       local merge(parts) =
         std.foldl(
@@ -161,7 +161,7 @@
       + (
         if 'items' in schema
            && std.isObject(schema.items)
-        then self.schema(schema.items { _parents: [] })
+        then self.schema(schema.items + { _parents: [] })
         else r.nilvalue
       ),
     // foldEnd

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -1,8 +1,13 @@
 {
-  static: self.new(import 'static.libsonnet'),
-  dynamic: self.new(import 'dynamic.libsonnet'),
+  local engineTypes = {
+    static: import 'static.libsonnet',
+    dynamic: import 'dynamic.libsonnet',
+  },
 
-  new(r): {
+  new(engineType): {
+    engine: engineTypes[engineType],
+    local r = self.engine,
+
     nilvalue: r.nilvalue,
     toObject: r.toObject,
     nestInParents(parents, object): r.nestInParents('', parents, object),

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -173,6 +173,19 @@
       + self.nameParsed(schema, parsed),
     // foldEnd
   },
+  withValidation(): {
+    engine+: {
+      validate(schema, value)::
+        local validate = import 'github.com/Duologic/validate-libsonnet/main.libsonnet';
+        validate.checkParameters({
+          [schema._name]:
+            validate.schemaCheck(
+              value,
+              schema
+            ),
+        }),
+    },
+  },
 }
 
 // vim: foldmethod=marker foldmarker=foldStart,foldEnd foldlevel=0

--- a/test/test_fromSchema.jsonnet
+++ b/test/test_fromSchema.jsonnet
@@ -72,25 +72,53 @@ local db =
   })
 ;
 
-local schema = db['https://example.com/schemas/customer'];
-local library = crdsonnet.fromSchema('customer', schema, db);
-
 test.new(std.thisFile)
-+ test.case.new(
-  name='fromSchema smoke test',
-  test=test.expect.eq(
-    actual=
-    library.customer.withFirstName('John')
-    + library.customer.withLastName('Doe')
-    + library.customer.shipping_address.withStreetAddress('4B Main Street')
-    + library.customer.shipping_address.withCountry(),
-    expected={
-      first_name: 'John',
-      last_name: 'Doe',
-      shipping_address: {
-        street_address: '4B Main Street',
-        country: 'United States of America',
-      },
-    }
++ (
+  local schema = db['https://example.com/schemas/customer'];
+  local library = crdsonnet.fromSchema('customer', schema, db);
+
+  test.case.new(
+    name='fromSchema smoke test',
+    test=test.expect.eq(
+      actual=
+      library.customer.withFirstName('John')
+      + library.customer.withLastName('Doe')
+      + library.customer.shipping_address.withStreetAddress('4B Main Street')
+      + library.customer.shipping_address.withCountry(),
+      expected={
+        first_name: 'John',
+        last_name: 'Doe',
+        shipping_address: {
+          street_address: '4B Main Street',
+          country: 'United States of America',
+        },
+      }
+    )
+  )
+)
++ (
+  local schema = db['https://example.com/schemas/customer'];
+  local library = (
+    crdsonnet.schema.new('customer', schema)
+    + crdsonnet.schema.withSchemaDB(db)
+  ).library;
+
+  test.case.new(
+    name='schema.new smoke test',
+    test=test.expect.eq(
+      actual=
+      library.customer.withFirstName('John')
+      + library.customer.withLastName('Doe')
+      + library.customer.shipping_address.withStreetAddress('4B Main Street')
+      + library.customer.shipping_address.withCountry(),
+      expected={
+        first_name: 'John',
+        last_name: 'Doe',
+        shipping_address: {
+          street_address: '4B Main Street',
+          country: 'United States of America',
+        },
+      }
+    )
   )
 )


### PR DESCRIPTION
To accomodate for this feature without imposing it onto existing libraries, I've donequite a bit of refactoring.

The idea of this refactor is that one can compose the configuration needed to eventually render the library followed by exposing the library.

```jsonnet
local crdsonnet = import 'github.com/crdsonnet/crdsonnet/crdsonnet/main.libsonnet';

(
  crdsonnet.schema.new(name, schema)
  + crdsonnet.schema.withSchemaDB(schemaDB)
  + crdsonnet.schema.withValidation()
).library
```

The feature being added is in the `withValidation()` function, it'll inject an `assert` in the functions rendered by the `dynamic` engine that validates the parameters against the schema.