### PR TITLE
refactor: provide proper documented interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,10 @@ test:
 		RESULT=$$(($$RESULT + $$?)); \
 	done; \
 	exit $$RESULT
+
+.PHONY: docs
+docs:
+	jsonnet \
+		-J crdsonnet/vendor \
+		-S -c -m docs \
+		-e '(import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet").render(import "crdsonnet/main.libsonnet")'

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,8 @@ docs:
 
 crdsonnet/example/json_schema_static_output.libsonnet:
 	jsonnet -S -J crdsonnet/vendor json_schema_static.libsonnet | jsonnetfmt - > crdsonnet/example/json_schema_static_output.libsonnet
+
+.PHONY: fmt
+fmt:
+	@find . -path './.git' -prune -o -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- jsonnetfmt --no-use-implicit-plus -i

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ docs:
 		-J crdsonnet/vendor \
 		-S -c -m docs \
 		-e '(import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet").render(import "crdsonnet/main.libsonnet")'
+
+crdsonnet/example/json_schema_static_output.libsonnet:
+	jsonnet -S -J crdsonnet/vendor json_schema_static.libsonnet | jsonnetfmt - > crdsonnet/example/json_schema_static_output.libsonnet

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # CRDsonnet
 
-Generate a *runtime* Jsonnet library directly from JSON Schemas, CRDs or OpenAPI
-components.
+Generate a *runtime* Jsonnet library directly from JSON Schemas, CRDs or OpenAPI components.
 
-> This project has moved from POC to an alpha status. It can be consider it in a usable
-> state for production projects however there are no guarantees for a stable API.
+> This project has moved from POC to an alpha status. It can be consider it in a usable state for production projects however there are no guarantees for a stable API.
 
 ## Install
 
@@ -20,7 +18,7 @@ Generate a library from a CustomResourceDefinition:
 // main.libsonnet
 local crdsonnet = import 'github.com/crdsonnet/crdsonnet/crdsonnet/main.libsonnet';
 
-crdsonnet.fromCRD(
+crdsonnet.crd.render(
   someCustomResourceDefinition,
   'example.io'
 )
@@ -37,10 +35,7 @@ example.core.v1.someObject.new(name='example')
 
 ### Static rendering
 
-The library can render a static library, this can be useful when rendering them in-memory
-becomes too slow or for debugging purposes. The static rendering will represent the
-jsonnet as a string, however this kind of string manipulation is quite hard in jsonnet
-and the output can be quite ugly.
+The library can render a static library, this can be useful when rendering them in-memory becomes too slow or for debugging purposes. The static rendering will represent the jsonnet as a string, however this kind of string manipulation is quite hard in jsonnet and the output can be quite ugly.
 
 To do this, first set the `render` to 'static':
 
@@ -48,14 +43,15 @@ To do this, first set the `render` to 'static':
 // static.libsonnet
 local crdsonnet = import 'github.com/crdsonnet/crdsonnet/crdsonnet/main.libsonnet';
 
-local example =
-  crdsonnet.fromCRD(
-    someCustomResourceDefinition,
-    'example.io',
-    render='static'
-  );
+local processor =
+  crdsonnet.processor.new()
+  + crdsonnet.processor.withRenderEngineType('static');
 
-example
+crdsonnet.crd.render(
+  someCustomResourceDefinition,
+  'example.io',
+  processor,
+)
 ```
 
 Then tell jsonnet to expect a string as output:
@@ -80,8 +76,7 @@ xtd.inspect.inspect(example, 10)
 
 ### Documentation
 
-The dynamic rendering comes with documentation included. It leverages
-[docsonnet](https://github.com/jsonnet-libs/docsonnet).
+The dynamic rendering comes with documentation included. It leverages [docsonnet](https://github.com/jsonnet-libs/docsonnet).
 
 ```jsonnet
 // docs.libsonnet
@@ -108,17 +103,12 @@ jsonnet -J vendor -S -c -m docs docs.libsonnet
 
 ## Development
 
-This project is marked as alpha status. It can be consider it in a usable state for
-production projects however there are no guarantees for a stable API.
+This project is marked as alpha status. It can be consider it in a usable state for production projects however there are no guarantees for a stable API.
 
 ### Testing
 
-There are unit tests under `test/`, these can be run with `make test`, please make sure
-these succeed. When changing test cases, then please follow test-driven development and
-modify the test cases in separate commits that come before functional changes.
+There are unit tests under `test/`, these can be run with `make test`, please make sure these succeed. When changing test cases, then please follow test-driven development and modify the test cases in separate commits that come before functional changes.
 
 ### Documentation
 
-The code hasn't been documented yet, the aim is to primarily document the functions in
-`main.libsonnet` as an entry point to the lib. Other files/functions are currently
-considered 'internal' and might change without notice.
+The code hasn't been documented yet, the aim is to primarily document the functions in `main.libsonnet` as an entry point to the lib. Other files/functions are currently considered 'internal' and might change without notice.

--- a/crdsonnet/example/example_schema.json
+++ b/crdsonnet/example/example_schema.json
@@ -1,0 +1,52 @@
+{
+   "$defs": {
+      "address": {
+         "properties": {
+            "street_address": {
+               "type": "string"
+            },
+            "city": {
+               "type": "string"
+            },
+            "state": {
+               "type": "string"
+            },
+            "country": {
+               "default": "United States of America",
+               "enum": [
+                  "United States of America",
+                  "Canada"
+               ]
+            }
+         },
+         "required": [
+            "street_address",
+            "city",
+            "state"
+         ],
+         "type": "object"
+      }
+   },
+   "$id": "https://example.com/schemas/customer",
+   "properties": {
+      "first_name": {
+         "type": "string"
+      },
+      "last_name": {
+         "type": "string"
+      },
+      "shipping_address": {
+         "$ref": "#/$defs/address"
+      },
+      "billing_address": {
+         "$ref": "#/$defs/address"
+      }
+   },
+   "required": [
+      "first_name",
+      "last_name",
+      "shipping_address",
+      "billing_address"
+   ],
+   "type": "object"
+}

--- a/crdsonnet/example/jso
+++ b/crdsonnet/example/jso
@@ -1,0 +1,18 @@
+local crdsonnet = import '../main.libsonnet';
+
+local schema = import './example_schema.json';
+
+local lib = crdsonnet.schema.render('customer', schema);
+local c = lib.customer;
+
+local shippingAddress =
+  local address = c.shipping_address;
+  address.withStreetAddress('12 Church Lane')
+  + address.withCity('West York')
+  + address.withState('Dobberton')
+  + address.withCountry();
+
+c.withFirstName('John')
++ c.withLastName('Doe')
++ shippingAddress
++ c.withBillingAddress(shippingAddress.shipping_address)

--- a/crdsonnet/example/json_schema.libsonnet
+++ b/crdsonnet/example/json_schema.libsonnet
@@ -1,0 +1,18 @@
+local crdsonnet = import '../main.libsonnet';
+
+local schema = import './example_schema.json';
+
+local lib = crdsonnet.schema.render('customer', schema);
+local c = lib.customer;
+
+local shippingAddress =
+  local address = c.shipping_address;
+  address.withStreetAddress('12 Church Lane')
+  + address.withCity('West York')
+  + address.withState('Dobberton')
+  + address.withCountry();
+
+c.withFirstName('John')
++ c.withLastName('Doe')
++ shippingAddress
++ c.withBillingAddress(shippingAddress.shipping_address)

--- a/crdsonnet/example/json_schema_simple.libsonnet
+++ b/crdsonnet/example/json_schema_simple.libsonnet
@@ -1,0 +1,9 @@
+local crdsonnet = import '../main.libsonnet';
+
+local schema = import './example_schema.json';
+
+local lib = crdsonnet.schema.render('customer', schema);
+local c = lib.customer;
+
+c.withFirstName('John')
++ c.withLastName('Doe')

--- a/crdsonnet/example/json_schema_static.libsonnet
+++ b/crdsonnet/example/json_schema_static.libsonnet
@@ -1,0 +1,9 @@
+local crdsonnet = import '../main.libsonnet';
+
+local schema = import './example_schema.json';
+
+local staticProcessor =
+  crdsonnet.processor.new()
+  + crdsonnet.processor.withRenderEngineType('static');
+
+crdsonnet.schema.render('customer', schema, staticProcessor)

--- a/crdsonnet/example/json_schema_static_output.libsonnet
+++ b/crdsonnet/example/json_schema_static_output.libsonnet
@@ -1,0 +1,22 @@
+{
+  customer+: {
+    withBillingAddress(value): { billing_address: value },
+    withBillingAddressMixin(value): { billing_address+: value },
+    billing_address+: {
+      withCity(value): { billing_address+: { city: value } },
+      withCountry(value='United States of America'): { billing_address+: { country: value } },
+      withState(value): { billing_address+: { state: value } },
+      withStreetAddress(value): { billing_address+: { street_address: value } },
+    },
+    withFirstName(value): { first_name: value },
+    withLastName(value): { last_name: value },
+    withShippingAddress(value): { shipping_address: value },
+    withShippingAddressMixin(value): { shipping_address+: value },
+    shipping_address+: {
+      withCity(value): { shipping_address+: { city: value } },
+      withCountry(value='United States of America'): { shipping_address+: { country: value } },
+      withState(value): { shipping_address+: { state: value } },
+      withStreetAddress(value): { shipping_address+: { street_address: value } },
+    },
+  },
+}

--- a/crdsonnet/example/json_schema_very_simple.libsonnet
+++ b/crdsonnet/example/json_schema_very_simple.libsonnet
@@ -1,0 +1,14 @@
+local crdsonnet = import '../main.libsonnet';
+
+local schema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+    },
+  },
+};
+
+local lib = crdsonnet.schema.render('person', schema);
+
+lib.person.withName('John')

--- a/crdsonnet/example/json_schema_very_simple_static.libsonnet
+++ b/crdsonnet/example/json_schema_very_simple_static.libsonnet
@@ -1,0 +1,16 @@
+local crdsonnet = import '../main.libsonnet';
+
+local schema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+    },
+  },
+};
+
+local staticProcessor =
+  crdsonnet.processor.new()
+  + crdsonnet.processor.withRenderEngineType('static');
+
+crdsonnet.schema.render('person', schema, staticProcessor)

--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -101,7 +101,7 @@ local defaultRender = 'dynamic';
     },
 
   openapi: {
-    process(
+    render(
       name,
       component,
       schema,
@@ -161,7 +161,7 @@ local defaultRender = 'dynamic';
         self.processor.new()
         + self.processor.withSchemaDB(schemaDB)
         + self.processor.withRenderEngineType(render);
-      self.openapi.process(name, component, schema, processor),
+      self.openapi.render(name, component, schema, processor),
 
   // expects schema as rendered by `kubectl get --raw /openapi/v2`
   fromKubernetesOpenAPI(schema, render=defaultRender):

--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -123,7 +123,11 @@ local defaultRender = 'dynamic';
          then processor.renderEngine.newFunction([name])
          else processor.renderEngine.nilvalue),
   },
+}
 
+// Legacy API endpoints
+// These endpoints aren't very flexible and require more arguments to add features, this is an anti-pattern. They have been reimplemented to use above modular setup as an example and to verify the modular pattern works. These functions are covered by unit tests.
++ {
   fromSchema(name, schema, schemaDB={}, render=defaultRender):
     if name == ''
     then error "name can't be an empty string"
@@ -161,7 +165,6 @@ local defaultRender = 'dynamic';
 
   // expects schema as rendered by `kubectl get --raw /openapi/v2`
   fromKubernetesOpenAPI(schema, render=defaultRender):
-    // foldStart
     std.foldl(
       function(acc, d)
         local items = std.reverse(std.split(d, '.'));
@@ -177,5 +180,4 @@ local defaultRender = 'dynamic';
       std.objectFields(schema.definitions),
       renderEngine.new(render).nilvalue
     ),
-  // foldEnd
 }

--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -1,6 +1,6 @@
 local helpers = import './helpers.libsonnet';
 local parser = import './parser.libsonnet';
-local renders = import './render.libsonnet';
+local renderEngine = import './render.libsonnet';
 
 local defaultRender = 'dynamic';
 
@@ -24,7 +24,7 @@ local defaultRender = 'dynamic';
         schema,
         schemaDB
       ) + { [name]+: { _name: name } };
-      renders[render].render(parsed[name]),
+      renderEngine.new(render).render(parsed[name]),
   // foldEnd
 
   fromCRD(definition, groupSuffix, schemaDB={}, render=defaultRender):
@@ -58,20 +58,20 @@ local defaultRender = 'dynamic';
     local output = std.foldl(
       function(acc, version)
         acc
-        + renders[render].toObject(
-          renders[render].nestInParents(
+        + renderEngine.new(render).toObject(
+          renderEngine.new(render).nestInParents(
             [grouping, version._name],
-            renders[render].schema(
+            renderEngine.new(render).schema(
               version[name]
             )
           )
         )
-        + renders[render].newFunction(
+        + renderEngine.new(render).newFunction(
           [grouping, version._name, name]
         )
       ,
       parsedVersions,
-      renders[render].nilvalue,
+      renderEngine.new(render).nilvalue,
     );
 
     output,
@@ -116,20 +116,20 @@ local defaultRender = 'dynamic';
     local output = std.foldl(
       function(acc, version)
         acc
-        + renders[render].toObject(
-          renders[render].nestInParents(
+        + renderEngine.new(render).toObject(
+          renderEngine.new(render).nestInParents(
             [grouping, version._name],
-            renders[render].schema(
+            renderEngine.new(render).schema(
               version[name]
             )
           )
         )
-        + renders[render].newFunction(
+        + renderEngine.new(render).newFunction(
           [grouping, version._name, name]
         )
       ,
       parsedVersions,
-      renders[render].nilvalue,
+      renderEngine.new(render).nilvalue,
     );
 
     output,
@@ -156,10 +156,10 @@ local defaultRender = 'dynamic';
         schemaDB
       ) + { [name]+: { _name: name } };
 
-      renders[render].render(parsed[name])
+      renderEngine.new(render).render(parsed[name])
       + (if 'x-kubernetes-group-version-kind' in component
-         then renders[render].newFunction([name])
-         else renders[render].nilvalue),
+         then renderEngine.new(render).newFunction([name])
+         else renderEngine.new(render).nilvalue),
   // foldEnd
 
   // expects schema as rendered by `kubectl get --raw /openapi/v2`
@@ -186,17 +186,17 @@ local defaultRender = 'dynamic';
         ) + { [name]+: { _name: name } };
 
         acc
-        + renders[render].toObject(
-          renders[render].nestInParents(
+        + renderEngine.new(render).toObject(
+          renderEngine.new(render).nestInParents(
             [items[2], items[1]],
-            renders[render].schema(parsed[name])
+            renderEngine.new(render).schema(parsed[name])
           )
         )
         + (if 'x-kubernetes-group-version-kind' in component
-           then renders[render].newFunction([items[2], items[1], name])
-           else renders[render].nilvalue),
+           then renderEngine.new(render).newFunction([items[2], items[1], name])
+           else renderEngine.new(render).nilvalue),
       std.objectFields(schema.definitions),
-      renders[render].nilvalue
+      renderEngine.new(render).nilvalue
     ),
   // foldEnd
 }

--- a/crdsonnet/parser.libsonnet
+++ b/crdsonnet/parser.libsonnet
@@ -78,7 +78,7 @@ local schemadb_util = import './schemadb.libsonnet';
     if parsed != null
     then
       if std.isObject(parsed[key])
-      then parsed[key] { _name:: key }
+      then parsed[key] + { _name:: key }
       else parsed[key]
     else {},
   // foldEnd
@@ -126,7 +126,7 @@ local schemadb_util = import './schemadb.libsonnet';
         else '';
 
       // Because order may matter (for example for prefixItems), we return a list.
-      parsed { [if name != '' then '_name']:: name }
+      parsed + { [if name != '' then '_name']:: name }
       for item in list
     ],
   // foldEnd

--- a/crdsonnet/parser.libsonnet
+++ b/crdsonnet/parser.libsonnet
@@ -2,13 +2,6 @@ local schemadb_util = import './schemadb.libsonnet';
 {
   local this = self,
 
-  getID(schema):
-    if '$id' in schema
-    then schema['$id']
-    else if 'id' in schema
-    then schema.id
-    else '',  //std.trace("Can't find '$id' (or 'id') in schema", ''),
-
   getRefName(ref): std.reverse(std.split(ref, '/'))[0],
 
   getURIBase(uri): std.join('/', std.splitLimit(uri, '/', 5)[0:3]),
@@ -167,7 +160,7 @@ local schemadb_util = import './schemadb.libsonnet';
       // Relative reference
       else if std.startsWith(ref, '/')
       then
-        local baseURI = self.getURIBase(this.getID(currentSchema));
+        local baseURI = self.getURIBase(schemadb_util.getID(currentSchema));
         if std.member(ref, '#')
         // Relative reference with fragment
         then getFragment(baseURI, ref)

--- a/crdsonnet/processor.libsonnet
+++ b/crdsonnet/processor.libsonnet
@@ -1,0 +1,58 @@
+local parser = import './parser.libsonnet';
+local renderEngine = import './render.libsonnet';
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#': d.package.newSub(
+    'processor',
+    |||
+      `processor` provides and interface to configure the parser and render engine, returns a parser() and render() function.
+    |||
+  ),
+
+  '#new': d.fn(
+    |||
+      `new` initializes the processor with sane defaults, returning a parser() and render() function.
+    |||,
+  ),
+  new(): {
+    schemaDB: {},
+    renderEngine: renderEngine.new('dynamic'),
+    parse(name, schema):
+      parser.parseSchema(
+        name,
+        schema,
+        schema,
+        self.schemaDB
+      ) + { [name]+: { _name: name } },
+    render(name, schema):
+      local parsedSchema = self.parse(name, schema);
+      self.renderEngine.render(parsedSchema[name]),
+  },
+  '#withSchemaDB': d.fn(
+    |||
+      `withSchemaDB` adds additional schema databases. These can be created with `crdsonnet.schemaDB`.
+    |||,
+    args=[d.arg('db', d.T.object)],
+  ),
+  withSchemaDB(db): {
+    schemaDB+: db,
+  },
+  '#withRenderEngine': d.fn(
+    |||
+      `withRenderEngine` configures an alternative render engine. This can be created with `crdsonnet.renderEngine`.
+    |||,
+    args=[d.arg('engine', d.T.object)],
+  ),
+  withRenderEngine(engine): {
+    renderEngine: engine,
+  },
+  '#withRenderEngineType': d.fn(
+    |||
+      `withRenderEngineType` is a shortcut to configure an alternative render engine type.
+    |||,
+    args=[d.arg('engineType', d.T.string, enums=['dynamic', 'static'])],
+  ),
+  withRenderEngineType(engineType):
+    self.withRenderEngine(renderEngine.new(engineType)),
+}

--- a/crdsonnet/processor.libsonnet
+++ b/crdsonnet/processor.libsonnet
@@ -6,7 +6,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   '#': d.package.newSub(
     'processor',
     |||
-      `processor` provides and interface to configure the parser and render engine, returns a parser() and render() function.
+      `processor` provides an interface to configure the parser and render engine, returns a parser() and render() function.
     |||
   ),
 

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -141,7 +141,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         else r.nilvalue
       );
 
-      local xofParts = self.xofParts(schema { _parents: super._parents[1:] });
+      local xofParts = self.xofParts(schema + { _parents: super._parents[1:] });
 
       local merge(parts) =
         if std.isObject(parts)
@@ -177,7 +177,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       + (
         if 'items' in schema
            && std.isObject(schema.items)
-        then self.schema(schema.items { _parents: [] })
+        then self.schema(schema.items + { _parents: [] })
         else r.nilvalue
       ),
     // foldEnd

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -1,8 +1,13 @@
 {
-  static: self.new(import 'static.libsonnet'),
-  dynamic: self.new(import 'dynamic.libsonnet'),
+  local engineTypes = {
+    static: import 'static.libsonnet',
+    dynamic: import 'dynamic.libsonnet',
+  },
 
-  new(r): {
+  new(engineType): {
+    engine: engineTypes[engineType],
+    local r = self.engine,
+
     nilvalue: r.nilvalue,
     toObject: r.toObject,
     nestInParents(parents, object): r.nestInParents('', parents, object),

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -1,9 +1,22 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
 {
   local engineTypes = {
     static: import 'static.libsonnet',
     dynamic: import 'dynamic.libsonnet',
   },
 
+  '#': d.package.newSub(
+    'renderEngine',
+    '`renderEngine` provides an interface to create a renderEngine.',
+  ),
+
+  '#new': d.fn(
+    '`new` returns a renderEngine.',
+    args=[
+      d.arg('engineType', d.T.string, enums=['static', 'dynamic']),
+    ],
+  ),
   new(engineType): {
     engine: engineTypes[engineType],
     local r = self.engine,

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -131,15 +131,18 @@
       local xofParts = self.xofParts(schema { _parents: super._parents[1:] });
 
       local merge(parts) =
-        std.foldl(
-          function(acc, k)
-            acc +
-            (if std.isObject(parts[k])
-             then parts[k]
-             else {}),
-          std.objectFields(parts),
-          {}
-        );
+        if std.isObject(parts)
+        then
+          std.foldl(
+            function(acc, k)
+              acc +
+              (if std.isObject(parts[k])
+               then parts[k]
+               else {}),
+            std.objectFields(parts),
+            {}
+          )
+        else parts;  // Can't merge in static mode
 
       // Merge allOf/anyOf as they can be used in combination with each other
       // Keep oneOf seperate as it they would not be used in combination with each other

--- a/crdsonnet/schemadb.libsonnet
+++ b/crdsonnet/schemadb.libsonnet
@@ -1,14 +1,44 @@
-local parser = import './parser.libsonnet';
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
 {
-  get(db, name):
-    if name in db
-    then db[name]
-    else {},
+  '#': d.package.newSub(
+    'schemaDB',
+    '`schemaDB` provides an interface to describe a schemaDB.',
+  ),
 
+  '#get': d.fn(
+    "`get` gets a schema from a 'db'.",
+    args=[
+      d.arg('db', d.T.object),
+      d.arg('name', d.T.string),
+    ],
+  ),
+  get(db, name):
+    std.get(db, name, {}),
+
+  '#add': d.fn(
+    "`add` adds a schema to a 'db', expects a schema to have either am `$id` or `id` field.",
+    args=[d.arg('schema', d.T.object)],
+  ),
   add(schema):
-    local id = parser.getID(schema);
+    local id = self.getID(schema);
     if id == ''
     then error "Can't add schema without id"
     else { [id]: schema },
+
+  '#getID': d.fn(
+    '`getID` gets the ID from a schema, either `$id` or `id` are returned.',
+    args=[d.arg('schema', d.T.object)],
+  ),
+  getID(schema):
+    std.get(
+      schema,
+      '$id',
+      std.get(
+        schema,
+        'id',
+        ''
+      )
+    ),
+
 }

--- a/crdsonnet/static.libsonnet
+++ b/crdsonnet/static.libsonnet
@@ -4,13 +4,17 @@
   nilvalue:: '',
 
   nestInParents(name, parents, object)::
+    local obj = std.stripChars(
+      object,
+      '{}',  // Remove curly brackets it can be nested in parents
+    );
     std.foldr(
       function(p, acc)
         if p == name
         then acc
         else '"' + p + '"+: { ' + acc + ' }',
       parents,
-      object
+      obj
     ),
 
   functionName(name)::

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,10 +11,77 @@ jb install https://github.com/crdsonnet/crdsonnet/crdsonnet@master
 ## Usage
 
 ```jsonnet
-local crdsonnet = import "https://github.com/crdsonnet/crdsonnet/crdsonnet/crdsonnet/main.libsonnet"
+local crdsonnet = import 'github.com/crdsonnet/crdsonnet/crdsonnet/main.libsonnet';
+
+local schema = import './example_schema.json';
+
+local lib = crdsonnet.schema.render('customer', schema);
+local c = lib.customer;
+
+c.withFirstName('John')
++ c.withLastName('Doe')
+
 ```
 
 ## Subpackages
 
 * [processor](crdsonnet/processor.md)
+* [renderEngine](crdsonnet/renderEngine.md)
+* [schemaDB](crdsonnet/schemaDB.md)
 
+## Index
+
+* [`obj crd`](#obj-crd)
+  * [`fn render(definition, groupSuffix, processor="processor.new()")`](#fn-crdrender)
+* [`obj openapi`](#obj-openapi)
+  * [`fn render(name, component, schema, processor="processor.new()")`](#fn-openapirender)
+* [`obj schema`](#obj-schema)
+  * [`fn render(name, schema, processor="processor.new()")`](#fn-schemarender)
+* [`obj xrd`](#obj-xrd)
+  * [`fn render(definition, groupSuffix, processor="processor.new()")`](#fn-xrdrender)
+
+## Fields
+
+### obj crd
+
+
+#### fn crd.render
+
+```ts
+render(definition, groupSuffix, processor="processor.new()")
+```
+
+`render` returns a library for a `definition`.
+
+### obj openapi
+
+
+#### fn openapi.render
+
+```ts
+render(name, component, schema, processor="processor.new()")
+```
+
+`render` returns a library for a `component` in an OpenAPI `schema`.
+
+### obj schema
+
+
+#### fn schema.render
+
+```ts
+render(name, schema, processor="processor.new()")
+```
+
+`render` returns a library for a `schema`.
+
+### obj xrd
+
+
+#### fn xrd.render
+
+```ts
+render(definition, groupSuffix, processor="processor.new()")
+```
+
+`render` returns a library for a `definition`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# crdsonnet
+
+Generate a *runtime* Jsonnet library directly from JSON Schemas, CRDs or OpenAPI components.
+
+## Install
+
+```
+jb install https://github.com/crdsonnet/crdsonnet/crdsonnet@master
+```
+
+## Usage
+
+```jsonnet
+local crdsonnet = import "https://github.com/crdsonnet/crdsonnet/crdsonnet/crdsonnet/main.libsonnet"
+```
+
+## Subpackages
+
+* [processor](crdsonnet/processor.md)
+

--- a/docs/crdsonnet/processor.md
+++ b/docs/crdsonnet/processor.md
@@ -1,0 +1,51 @@
+# processor
+
+`processor` provides and interface to configure the parser and render engine, returns a parser() and render() function.
+
+
+## Index
+
+* [`fn new()`](#fn-new)
+* [`fn withRenderEngine(engine)`](#fn-withrenderengine)
+* [`fn withRenderEngineType(engineType)`](#fn-withrenderenginetype)
+* [`fn withSchemaDB(db)`](#fn-withschemadb)
+
+## Fields
+
+### fn new
+
+```ts
+new()
+```
+
+`new` initializes the processor with sane defaults, returning a parser() and render() function.
+
+
+### fn withRenderEngine
+
+```ts
+withRenderEngine(engine)
+```
+
+`withRenderEngine` configures an alternative render engine. This can be created with `crdsonnet.renderEngine`.
+
+
+### fn withRenderEngineType
+
+```ts
+withRenderEngineType(engineType)
+```
+
+`withRenderEngineType` is a shortcut to configure an alternative render engine type.
+
+
+Accepted values for `engineType` are "dynamic", "static"
+
+### fn withSchemaDB
+
+```ts
+withSchemaDB(db)
+```
+
+`withSchemaDB` adds additional schema databases. These can be created with `crdsonnet.schemaDB`.
+

--- a/docs/crdsonnet/processor.md
+++ b/docs/crdsonnet/processor.md
@@ -1,6 +1,6 @@
 # processor
 
-`processor` provides and interface to configure the parser and render engine, returns a parser() and render() function.
+`processor` provides an interface to configure the parser and render engine, returns a parser() and render() function.
 
 
 ## Index

--- a/docs/crdsonnet/renderEngine.md
+++ b/docs/crdsonnet/renderEngine.md
@@ -1,0 +1,19 @@
+# renderEngine
+
+`renderEngine` provides an interface to create a renderEngine.
+
+## Index
+
+* [`fn new(engineType)`](#fn-new)
+
+## Fields
+
+### fn new
+
+```ts
+new(engineType)
+```
+
+`new` returns a renderEngine.
+
+Accepted values for `engineType` are "static", "dynamic"

--- a/docs/crdsonnet/schemaDB.md
+++ b/docs/crdsonnet/schemaDB.md
@@ -1,0 +1,35 @@
+# schemaDB
+
+`schemaDB` provides an interface to describe a schemaDB.
+
+## Index
+
+* [`fn add(schema)`](#fn-add)
+* [`fn get(db, name)`](#fn-get)
+* [`fn getID(schema)`](#fn-getid)
+
+## Fields
+
+### fn add
+
+```ts
+add(schema)
+```
+
+`add` adds a schema to a 'db', expects a schema to have either am `$id` or `id` field.
+
+### fn get
+
+```ts
+get(db, name)
+```
+
+`get` gets a schema from a 'db'.
+
+### fn getID
+
+```ts
+getID(schema)
+```
+
+`getID` gets the ID from a schema, either `$id` or `id` are returned.


### PR DESCRIPTION
This PR refactors the `from*()` endpoints to use a modular approach for creating the parser and render engine, this modular approach allows us to add features more gradually without having ever-expanding arguments on the `from*()` functions.

I've also taken this opportunity to document a lot of the code so it becomes easier to use and understand. 