### PR TITLE
feat: render subpackage docstrings when array.items is an object

### DIFF
--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -157,20 +157,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
       // Merge allOf/anyOf as they can be used in combination with each other
       // Keep oneOf seperate as it they would not be used in combination with each other
+      local _parsed =
+        (if std.get(schema, '_package', false)
+         then r.objectSubpackage(schema)
+         else r.nilvalue)
+        + merge(xofParts.allOf)
+        + merge(xofParts.anyOf)
+        + xofParts.oneOf
+        + properties;
+
       local parsed =
         if engineType == 'ast'
-        then
-          jutils.deepMergeObjectFields(
-            merge(xofParts.allOf)
-            + merge(xofParts.anyOf)
-            + xofParts.oneOf
-            + properties
-          )
-        else
-          merge(xofParts.allOf)
-          + merge(xofParts.anyOf)
-          + xofParts.oneOf
-          + properties;
+        then jutils.deepMergeObjectFields(_parsed)
+        else _parsed;
 
       self.functions(schema)
       + self.nameParsed(schema, parsed),
@@ -182,7 +181,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       + (
         if 'items' in schema
            && std.isObject(schema.items)
-        then self.schema(schema.items + { _parents: [] })
+        then self.schema(schema.items + { _parents: [], _package: true })
         else r.nilvalue
       ),
 

--- a/crdsonnet/renderEngines/ast.libsonnet
+++ b/crdsonnet/renderEngines/ast.libsonnet
@@ -52,6 +52,15 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     ]);
     'with' + std.asciiUpper(n[0]) + n[1:],
 
+  objectSubpackage(schema):: [
+    customField.field(
+      j.fieldname.string('#'),
+      j.literal(
+        d.package.newSub(schema._name, '')
+      )
+    ),
+  ],
+
   functionHelp(functionName, schema)::
     customField.field(
       j.fieldname.string('#' + functionName),

--- a/crdsonnet/renderEngines/dynamic.libsonnet
+++ b/crdsonnet/renderEngines/dynamic.libsonnet
@@ -28,6 +28,10 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     ]);
     'with' + std.asciiUpper(n[0]) + n[1:],
 
+  objectSubpackage(schema):: {
+    '#':: d.package.newSub(schema._name, ''),
+  },
+
   functionHelp(functionName, schema):: {
     ['#%s' % functionName]::
       d.fn(

--- a/crdsonnet/renderEngines/static.libsonnet
+++ b/crdsonnet/renderEngines/static.libsonnet
@@ -28,6 +28,8 @@
     ]);
     'with' + std.asciiUpper(n[0]) + n[1:],
 
+  objectSubpackage(schema):: '',
+
   withFunction(schema)::
     |||
       %s(value%s): { %s },


### PR DESCRIPTION
**Background**

When an array defines a schema for it's items, crdsonnet creates two sets of code:

- Functions to add the item to the array
- A subcomponent with functions to create the item

They should be used like this:

```jsonnet
local listObject = myObj.list.withSomething();

myObj.new()
+ myObj.withList([listObject])
```

But this is hard to infer from the documentation as the distinction between setting properties on `myObj` and having to create the `listObject` separately.

It often gets interpreted like this:

```jsonnet

myObj.new()
+ myObj.list.withSomething()
```

This will yield an invalid object.

**Fix**

In this PR, CRDsonnet now calls `d.package.newSub`, this will tell Docsonnet to render the item definition `myObj.list` as a separate file. This will help end users make a better distinction to object properties and objects that are separate (sub?) entities.

This fix doesn't make it entirely explicit, library builders should consider extending the docs of these sub packages with examples on how to properly use them.

This fix doesn't change the actual structure of the library, only affecting the output of the docs.