### PR TITLE
fix(render): cleaner rendering without duplicates

### DIFF
--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -157,25 +157,31 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
       // Merge allOf/anyOf as they can be used in combination with each other
       // Keep oneOf seperate as it they would not be used in combination with each other
-      local _parsed =
-        (if std.get(schema, '_package', false)
-         then r.objectSubpackage(schema)
-         else r.nilvalue)
-        + merge(xofParts.allOf)
+      local parsedProperties =
+        merge(xofParts.allOf)
         + merge(xofParts.anyOf)
         + xofParts.oneOf
         + properties;
 
+      // Only create package if there are properties
+      local packagedProperties =
+        (if std.get(schema, '_package', false)
+            && parsedProperties != r.nilvalue
+         then r.objectSubpackage(schema)
+         else r.nilvalue)
+        + parsedProperties;
+
+      // Deep merge to prevent duplicate keys
       local parsed =
         if engineType == 'ast'
-        then jutils.deepMergeObjectFields(_parsed)
-        else _parsed;
+        then jutils.deepMergeObjectFields(packagedProperties)
+        else packagedProperties;
 
       self.functions(schema)
       + self.nameParsed(schema, parsed),
 
     array(schema):
-      (if '_name' in schema
+      (if '_name' in schema && schema._parents != []
        then r.arrayFunctions(schema)
        else r.nilvalue)
       + (


### PR DESCRIPTION
This PR fixes two minor problems:

- When an object doesn't have any properties, then don't create an (empty) package.
- When an array has `{ items: { type: array } }` then this would render the same `withX` functions again, this can be prevented by checking for empty `_parents`.