### PR TITLE
Support dashes as separators

### DIFF
--- a/crdsonnet/renderEngines/ast.libsonnet
+++ b/crdsonnet/renderEngines/ast.libsonnet
@@ -42,13 +42,13 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     ]),
 
   functionName(name)::
-    local underscores = std.set(std.findSubstr('_', name));
+    local separators = std.set(std.findSubstr('_', name) + std.findSubstr('-', name));
     local n = std.join('', [
-      if std.setMember(i - 1, underscores)
+      if std.setMember(i - 1, separators)
       then std.asciiUpper(name[i])
       else name[i]
       for i in std.range(0, std.length(name) - 1)
-      if !std.setMember(i, underscores)
+      if !std.setMember(i, separators)
     ]);
     'with' + std.asciiUpper(n[0]) + n[1:],
 

--- a/crdsonnet/renderEngines/static.libsonnet
+++ b/crdsonnet/renderEngines/static.libsonnet
@@ -18,13 +18,13 @@
     ),
 
   functionName(name)::
-    local underscores = std.set(std.findSubstr('_', name));
+    local separators = std.set(std.findSubstr('_', name) + std.findSubstr('-', name));
     local n = std.join('', [
-      if std.setMember(i - 1, underscores)
+      if std.setMember(i - 1, separators)
       then std.asciiUpper(name[i])
       else name[i]
       for i in std.range(0, std.length(name) - 1)
-      if !std.setMember(i, underscores)
+      if !std.setMember(i, separators)
     ]);
     'with' + std.asciiUpper(n[0]) + n[1:],
 


### PR DESCRIPTION
Example, an attribute called `cancel-in-progress` should yield a function called: `withCancelInProgress`

Currently, the output is `withCancel-in-progress`