### PR TITLE
Allow creating camelCase library fields

### DIFF
--- a/crdsonnet/processor.libsonnet
+++ b/crdsonnet/processor.libsonnet
@@ -60,6 +60,16 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   withRenderEngineType(engineType):
     self.withRenderEngine(renderEngine.new(engineType)),
 
+  '#withCamelCaseFields': d.fn(
+    |||
+      `withCamelCaseFields` configures the render engine to use camelCase field names.
+    |||,
+    args=[],
+  ),
+  withCamelCaseFields(): {
+    renderEngine+: super.renderEngine.withCamelCaseFields(),
+  },
+
   '#withValidation': d.fn(
     |||
       `withValidation` turns on schema validation for render engine 'dynamic'. The `with*()` functions will validate the inputs against the given schema.

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -1,6 +1,8 @@
+local helpers = import './helpers.libsonnet';
 local engines = import './renderEngines/main.libsonnet';
 local jutils = import 'github.com/Duologic/jsonnet-libsonnet/utils.libsonnet';
 local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
 {
   '#': d.package.newSub(
@@ -20,12 +22,17 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   ),
   new(engineType): {
     engine: engines[engineType],
+    camelCaseFields: false,
     local r = self.engine,
 
     nilvalue: r.nilvalue,
     toObject: r.toObject,
     nestInParents(parents, object): r.nestInParents('', parents, object),
     newFunction: r.newFunction,
+
+    withCamelCaseFields():: {
+      camelCaseFields: true,
+    },
 
     render(schema):
       r.toObject(self.schema(schema)),
@@ -69,7 +76,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
          && parsed != r.nilvalue
       then
         r.named(
-          schema._name,
+          if self.camelCaseFields then xtd.camelcase.toCamelCase(schema._name) else schema._name,
           r.toObject(
             parsed
           )

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -76,7 +76,9 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
          && parsed != r.nilvalue
       then
         r.named(
-          if self.camelCaseFields then xtd.camelcase.toCamelCase(schema._name) else schema._name,
+          if self.camelCaseFields then
+            xtd.camelcase.toCamelCase(schema._name)
+          else schema._name,
           r.toObject(
             parsed
           )

--- a/crdsonnet/renderEngines/ast.libsonnet
+++ b/crdsonnet/renderEngines/ast.libsonnet
@@ -43,14 +43,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     ]),
 
   functionName(name)::
-    local separators = std.set(std.findSubstr('_', name) + std.findSubstr('-', name));
-    local n = std.join('', [
-      if std.setMember(i - 1, separators)
-      then std.asciiUpper(name[i])
-      else name[i]
-      for i in std.range(0, std.length(name) - 1)
-      if !std.setMember(i, separators)
-    ]);
+    local n = xtd.camelcase.toCamelCase(name);
     'with' + std.asciiUpper(n[0]) + n[1:],
 
   objectSubpackage(schema):: [

--- a/crdsonnet/renderEngines/dynamic.libsonnet
+++ b/crdsonnet/renderEngines/dynamic.libsonnet
@@ -1,5 +1,7 @@
 local helpers = import '../helpers.libsonnet';
 local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
+
 {
   local this = self,
 
@@ -19,14 +21,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     ),
 
   functionName(name)::
-    local underscores = std.set(std.findSubstr('_', name));
-    local n = std.join('', [
-      if std.setMember(i - 1, underscores)
-      then std.asciiUpper(name[i])
-      else name[i]
-      for i in std.range(0, std.length(name) - 1)
-      if !std.setMember(i, underscores)
-    ]);
+    local n = xtd.camelcase.toCamelCase(name);
     'with' + std.asciiUpper(n[0]) + n[1:],
 
   objectSubpackage(schema):: {


### PR DESCRIPTION
See the `test/test_fromSchema.jsonnet` file for an example
- Rather than using the field name directly, convert them to camelCase so it's prettier and nicer to use
- This is especially useful when field names have dashes in them. example from the Github Actions schema: ` wf.permissions['permissions-event'].withActions('write')` -> ` wf.permissions.permissionsEvent.withActions('write')`
- This is an option to set on the processor to allow breaking current uses of CRDsonnet