### PR TITLE
fix: render CRDs with AST engine

### DIFF
--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -67,15 +67,16 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         std.foldl(
           function(acc, version)
             local schema = this.getSchemaForVersion(definition, version);
-            acc
-            + renderEngine.nestInParents(
-              [grouping, version.name],
-              _processor.render(name, schema)
-            )
-            + renderEngine.newFunction(
-              [grouping, version.name, name]
-            )
-          ,
+            renderEngine.mergeFields(
+              acc
+              + renderEngine.newFunction(
+                [grouping, version.name]
+              )
+              + renderEngine.nestInParents(
+                [grouping, version.name],
+                _processor.render(name, schema)
+              )
+            ),
           definition.spec.versions,
           renderEngine.nilvalue,
         )

--- a/crdsonnet/main.libsonnet
+++ b/crdsonnet/main.libsonnet
@@ -70,7 +70,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
             renderEngine.mergeFields(
               acc
               + renderEngine.newFunction(
-                [grouping, version.name]
+                [grouping, version.name, name]
               )
               + renderEngine.nestInParents(
                 [grouping, version.name],

--- a/crdsonnet/render.libsonnet
+++ b/crdsonnet/render.libsonnet
@@ -29,6 +29,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     toObject: r.toObject,
     nestInParents(parents, object): r.nestInParents('', parents, object),
     newFunction: r.newFunction,
+    mergeFields(fields):
+      if engineType == 'ast'
+      then jutils.deepMergeObjectFields(fields)
+      else fields,
 
     withCamelCaseFields():: {
       camelCaseFields: true,

--- a/crdsonnet/renderEngines/ast.libsonnet
+++ b/crdsonnet/renderEngines/ast.libsonnet
@@ -281,27 +281,39 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     this.nestInParents(
       '',
       parents,
-      local params = [j.id('name')];
-      customField.func(
-        j.id('new'),
-        j.binary(
-          '+',
-          [
-            j.functioncall(j.fieldaccess([j.id('self')], j.id('withApiVersion'))),
-            j.functioncall(j.fieldaccess([j.id('self')], j.id('withKind'))),
-            j.functioncall(
-              j.fieldaccess(
-                [
-                  j.id('self'),
-                  j.id('metadata'),
-                ],
-                j.id('withName')
-              ),
-              args=params
+      self.toObject([
+        j.field.field(
+          j.fieldname.string('#new'),
+          j.literal(
+            d.func.new(
+              '`new` creates a new instance',
+              [d.arg('name', d.T.string)],
             ),
-          ],
+          ),
+          nobreak=true,
         ),
-        params=params,
-      ),
+        local params = [j.id('name')];
+        customField.func(
+          j.id('new'),
+          j.binary(
+            '+',
+            [
+              j.functioncall(j.fieldaccess([j.id('self')], j.id('withApiVersion'))),
+              j.functioncall(j.fieldaccess([j.id('self')], j.id('withKind'))),
+              j.functioncall(
+                j.fieldaccess(
+                  [
+                    j.id('self'),
+                    j.id('metadata'),
+                  ],
+                  j.id('withName')
+                ),
+                args=params
+              ),
+            ],
+          ),
+          params=params,
+        ),
+      ])
     ),
 }


### PR DESCRIPTION
The CRD/XRD render function could not work with the AST engine, this PR attempts to fix it. I've tested this change internally at Grafana with both the `dynamic` and `ast` engine, there were no regressions AFAICT.

This addresses the problems surfaced here: https://github.com/crdsonnet/crdsonnet/pull/12#discussion_r1315809890