### PR TITLE
fix: Add missing namespace property to writeConnectionSecretToRef

### DIFF
--- a/crdsonnet/helpers.libsonnet
+++ b/crdsonnet/helpers.libsonnet
@@ -76,8 +76,8 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
               type: 'string',
             },
             writeConnectionSecretToRef: {
-              properties: { name: { type: 'string' } },
-              required: ['name'],
+              properties: { name: { type: 'string' }, namespace: { type: 'string' } },
+              required: ['name', 'namespace'],
               type: 'object',
             },
           },


### PR DESCRIPTION
This PR adds the missing required property `namespace` to the Crossplane `writeConnectionSecretToRef` object.