### PR TITLE
fix: merge  with other keywords

### DIFF
--- a/crdsonnet/resolver.libsonnet
+++ b/crdsonnet/resolver.libsonnet
@@ -49,7 +49,11 @@ local schemadb_util = import './schemadb.libsonnet';
 
   resolveRef(obj, schema, schemaDB):
     if '$ref' in obj
-    then self.resolve(obj['$ref'], schema, schemaDB)
+    then
+      std.mergePatch(
+        std.mergePatch(obj, { '$ref': null }),  // Remove $ref
+        self.resolve(obj['$ref'], schema, schemaDB)  // Merge with sibling keywords (=>draft-2019-09)
+      )
     else obj,
 
   resolve(ref, schema, schemaDB):


### PR DESCRIPTION
A new attempt at https://github.com/crdsonnet/crdsonnet/pull/6:

> In Draft 4-7, $ref behaves a little differently. When an object contains a $ref property, the object is considered a reference, not a schema. Therefore, any other properties you put in that object will not be treated as JSON Schema keywords and will be ignored by the validator. $ref can only be used where a schema is expected.
_source:_ http://json-schema.org/understanding-json-schema/structuring.html#id18

Since draft-2019-09 this behavior has changed and is now merged.

I've run into this with https://github.com/crdsonnet/github-actions-libsonnet/pull/2, the github-workflow.json schema relies on this pattern quite a bit.

This PR learned me a neat trick: `std.mergePatch` can be used to remove fields from an object. It follows RFC 7396 which states:

> Null values in the merge patch are given special meaning to indicate the removal of existing values in the target.

I'm not sure what the impact will be on existing libraries, I assume it'll actually render them more correctly.
